### PR TITLE
Change UART pattern detection function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(ATOMVM_GPS_COMPONENT_SRCS
 idf_component_register(
     SRCS ${ATOMVM_GPS_COMPONENT_SRCS}
     INCLUDE_DIRS "ports/include"
-    PRIV_REQUIRES "libatomvm" "avm_sys" "driver"
+    PRIV_REQUIRES "esp_event" "libatomvm" "avm_sys" "driver"
 )
 
 idf_build_set_property(

--- a/ports/nmea_parser.c
+++ b/ports/nmea_parser.c
@@ -682,7 +682,8 @@ nmea_parser_handle_t nmea_parser_init(const nmea_parser_config_t *config)
         .data_bits = config->uart.data_bits,
         .parity = config->uart.parity,
         .stop_bits = config->uart.stop_bits,
-        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .source_clk = UART_SCLK_DEFAULT
     };
     if (uart_param_config(esp_gps->uart_port, &uart_config) != ESP_OK) {
         ESP_LOGE(GPS_TAG, "config uart parameter failed");

--- a/ports/nmea_parser.c
+++ b/ports/nmea_parser.c
@@ -700,7 +700,7 @@ nmea_parser_handle_t nmea_parser_init(const nmea_parser_config_t *config)
         goto err_uart_install;
     }
     /* Set pattern interrupt, used to detect the end of a line */
-    uart_enable_pattern_det_intr(esp_gps->uart_port, '\n', 1, 10000, 10, 10);
+    uart_enable_pattern_det_baud_intr(esp_gps->uart_port, '\n', 1, 9, 0, 0);
     /* Set pattern queue size */
     uart_pattern_queue_reset(esp_gps->uart_port, config->uart.event_queue_size);
     uart_flush(esp_gps->uart_port);

--- a/ports/nmea_parser.h
+++ b/ports/nmea_parser.h
@@ -153,7 +153,7 @@ typedef void *nmea_parser_handle_t;
     {                                      \
         .uart = {                          \
             .uart_port = UART_NUM_1,       \
-            .rx_pin = 2,                   \
+            .rx_pin = CONFIG_NMEA_PARSER_UART_RXD,                   \
             .baud_rate = 9600,             \
             .data_bits = UART_DATA_8_BITS, \
             .parity = UART_PARITY_DISABLE, \


### PR DESCRIPTION
This PR enables the component to be built using IDF v5.0.2.

The function `uart_enable_pattern_det_intr` seems to be deprecated in v4.4.

