### PR TITLE
increase default stack size

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -18,7 +18,7 @@ config AVM_GPS_ENABLE
         config NMEA_PARSER_TASK_STACK_SIZE
             int "NMEA Parser Task Stack Size"
             range 0 4096
-            default 2048
+            default 3072
             help
                 Stack size of NMEA Parser task.
 


### PR DESCRIPTION
upstream has increased default stack (for S3) - see https://github.com/espressif/esp-idf/commit/c7aab676d4deefd7139917c59d2c08ac5604f7e8