### PR TITLE
fix GPS_UNKNOWN locking process/queue

### DIFF
--- a/ports/atomvm_gps.c
+++ b/ports/atomvm_gps.c
@@ -260,6 +260,9 @@ static void gps_event_handler(void *event_handler_arg, esp_event_base_t event_ba
 
         case GPS_UNKNOWN:
             ESP_LOGW(TAG, "Unknown statement:%s", (char *)event_data);
+
+            globalcontext_get_process_unlock(global, target);
+
             break;
 
         default:


### PR DESCRIPTION
currently a GPS_UNKNOWN event would NOT unlock the process, and the process/queue would stall and no further gps events received.

```
[0;33mW (1066) atomvm_gps: Unknown statement:ªj±,V,,,,,,,,,,N*53

[0m
[0;33mW (4186) uart: Fail to enqueue pattern position, pattern queue is full.[0m
[0;33mW (4206) uart: Fail to enqueue pattern position, pattern queue is full.[0m
[0;33mW (5056) uart: Fail to enqueue pattern position, pattern queue is full.[0m
[0;33mW (5086) uart: Fail to enqueue pattern position, pattern queue is full.[0m
[0;33mW (5116) uart: Fail to enqueue pattern position, pattern queue is full.[0m
```

this can be provoked by resetting the esp a few times to catch a partial message resulting in a GPS_UNKNOWN event - and would lock the queue.

Additionally I theorize that my gps module occasionally sends some kind of GPS_UNKNOWN messages.

Tested on device, and provoking a GPS_UNKNOWN event keeps the events/queue going with this fix.